### PR TITLE
remove leading backslash from namespace

### DIFF
--- a/src/HtaccessCapabilityTester.php
+++ b/src/HtaccessCapabilityTester.php
@@ -2,21 +2,21 @@
 
 namespace HtaccessCapabilityTester;
 
-use \HtaccessCapabilityTester\Testers\AbstractTester;
-use \HtaccessCapabilityTester\Testers\AddTypeTester;
-use \HtaccessCapabilityTester\Testers\ContentDigestTester;
-use \HtaccessCapabilityTester\Testers\CrashTester;
-use \HtaccessCapabilityTester\Testers\CustomTester;
-use \HtaccessCapabilityTester\Testers\DirectoryIndexTester;
-use \HtaccessCapabilityTester\Testers\HeaderSetTester;
-use \HtaccessCapabilityTester\Testers\HtaccessEnabledTester;
-use \HtaccessCapabilityTester\Testers\InnocentRequestTester;
-use \HtaccessCapabilityTester\Testers\ModuleLoadedTester;
-use \HtaccessCapabilityTester\Testers\PassInfoFromRewriteToScriptThroughRequestHeaderTester;
-use \HtaccessCapabilityTester\Testers\PassInfoFromRewriteToScriptThroughEnvTester;
-use \HtaccessCapabilityTester\Testers\RewriteTester;
-use \HtaccessCapabilityTester\Testers\RequestHeaderTester;
-use \HtaccessCapabilityTester\Testers\ServerSignatureTester;
+use HtaccessCapabilityTester\Testers\AbstractTester;
+use HtaccessCapabilityTester\Testers\AddTypeTester;
+use HtaccessCapabilityTester\Testers\ContentDigestTester;
+use HtaccessCapabilityTester\Testers\CrashTester;
+use HtaccessCapabilityTester\Testers\CustomTester;
+use HtaccessCapabilityTester\Testers\DirectoryIndexTester;
+use HtaccessCapabilityTester\Testers\HeaderSetTester;
+use HtaccessCapabilityTester\Testers\HtaccessEnabledTester;
+use HtaccessCapabilityTester\Testers\InnocentRequestTester;
+use HtaccessCapabilityTester\Testers\ModuleLoadedTester;
+use HtaccessCapabilityTester\Testers\PassInfoFromRewriteToScriptThroughRequestHeaderTester;
+use HtaccessCapabilityTester\Testers\PassInfoFromRewriteToScriptThroughEnvTester;
+use HtaccessCapabilityTester\Testers\RewriteTester;
+use HtaccessCapabilityTester\Testers\RequestHeaderTester;
+use HtaccessCapabilityTester\Testers\ServerSignatureTester;
 
 /**
  * Main entrance.

--- a/src/TestResultCache.php
+++ b/src/TestResultCache.php
@@ -2,7 +2,7 @@
 
 namespace HtaccessCapabilityTester;
 
-use \HtaccessCapabilityTester\Testers\AbstractTester;
+use HtaccessCapabilityTester\Testers\AbstractTester;
 
 /**
  * Class caching test results

--- a/src/Testers/AbstractTester.php
+++ b/src/Testers/AbstractTester.php
@@ -2,13 +2,13 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\HtaccessCapabilityTester;
-use \HtaccessCapabilityTester\HttpRequesterInterface;
-use \HtaccessCapabilityTester\HttpResponse;
-use \HtaccessCapabilityTester\SimpleHttpRequester;
-use \HtaccessCapabilityTester\SimpleTestFileLineUpper;
-use \HtaccessCapabilityTester\TestFilesLineUpperInterface;
-use \HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\HtaccessCapabilityTester;
+use HtaccessCapabilityTester\HttpRequesterInterface;
+use HtaccessCapabilityTester\HttpResponse;
+use HtaccessCapabilityTester\SimpleHttpRequester;
+use HtaccessCapabilityTester\SimpleTestFileLineUpper;
+use HtaccessCapabilityTester\TestFilesLineUpperInterface;
+use HtaccessCapabilityTester\TestResult;
 
 abstract class AbstractTester
 {

--- a/src/Testers/CrashTester.php
+++ b/src/Testers/CrashTester.php
@@ -2,7 +2,7 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\TestResult;
 
 /**
  * Class for testing if a .htaccess results in a 500 Internal Server Error

--- a/src/Testers/CustomTester.php
+++ b/src/Testers/CustomTester.php
@@ -2,12 +2,12 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\HtaccessCapabilityTester;
-use \HtaccessCapabilityTester\HttpRequesterInterface;
-use \HtaccessCapabilityTester\HttpResponse;
-use \HtaccessCapabilityTester\SimpleHttpRequester;
-use \HtaccessCapabilityTester\TestResult;
-use \HtaccessCapabilityTester\Testers\Helpers\ResponseInterpreter;
+use HtaccessCapabilityTester\HtaccessCapabilityTester;
+use HtaccessCapabilityTester\HttpRequesterInterface;
+use HtaccessCapabilityTester\HttpResponse;
+use HtaccessCapabilityTester\SimpleHttpRequester;
+use HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\Testers\Helpers\ResponseInterpreter;
 
 class CustomTester extends AbstractTester
 {

--- a/src/Testers/Helpers/ResponseInterpreter.php
+++ b/src/Testers/Helpers/ResponseInterpreter.php
@@ -2,9 +2,9 @@
 
 namespace HtaccessCapabilityTester\Testers\Helpers;
 
-use \HtaccessCapabilityTester\HttpResponse;
-use \HtaccessCapabilityTester\TestResult;
-use \HtaccessCapabilityTester\Testers\AbstractTester;
+use HtaccessCapabilityTester\HttpResponse;
+use HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\Testers\AbstractTester;
 
 /**
  * Class for interpreting responses using a defined interpretation table.

--- a/src/Testers/HtaccessEnabledTester.php
+++ b/src/Testers/HtaccessEnabledTester.php
@@ -2,8 +2,8 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\HtaccessCapabilityTester;
-use \HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\HtaccessCapabilityTester;
+use HtaccessCapabilityTester\TestResult;
 
 /**
  * Class for testing if .htaccess files are processed

--- a/src/Testers/InnocentRequestTester.php
+++ b/src/Testers/InnocentRequestTester.php
@@ -2,7 +2,7 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\TestResult;
 
 /**
  * Class for testing if an innocent request for a txt file succeeds

--- a/src/Testers/ModuleLoadedTester.php
+++ b/src/Testers/ModuleLoadedTester.php
@@ -2,7 +2,7 @@
 
 namespace HtaccessCapabilityTester\Testers;
 
-use \HtaccessCapabilityTester\TestResult;
+use HtaccessCapabilityTester\TestResult;
 
 /**
  * Class for testing if a module is loaded.


### PR DESCRIPTION
Class not found error are thrown even though the class is there. I believe this is due to the leading backslash when using `use CLASSNAME`